### PR TITLE
fix: incidents for inactive/parked assets

### DIFF
--- a/application/src/main/java/fish/focus/uvms/incident/service/bean/IncidentServiceBean.java
+++ b/application/src/main/java/fish/focus/uvms/incident/service/bean/IncidentServiceBean.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Stateless
@@ -89,8 +90,12 @@ public class IncidentServiceBean {
 
         try {
             if (IncidentType.ASSET_NOT_SENDING.equals(ticket.getType())) {
-                String pollId = assetCommunication.createPollInternal(ticket);
-                ticket.setPollId(pollId);
+                Optional<String> pollId = assetCommunication.createPollInternal(ticket);
+                if (pollId.isEmpty()) {
+                    // don't create an incident for inactive/parked assets
+                    return;
+                }
+                ticket.setPollId(pollId.get());
             }
 
             Incident incident = incidentHelper.constructIncident(ticket);

--- a/application/src/test/java/fish/focus/uvms/incident/mock/AssetMock.java
+++ b/application/src/test/java/fish/focus/uvms/incident/mock/AssetMock.java
@@ -2,6 +2,7 @@ package fish.focus.uvms.incident.mock;
 
 import fish.focus.uvms.asset.client.model.AssetBO;
 import fish.focus.uvms.asset.client.model.AssetDTO;
+import fish.focus.uvms.asset.client.model.CreatePollResultDto;
 import fish.focus.uvms.asset.client.model.SimpleCreatePoll;
 import fish.focus.uvms.rest.security.RequiresFeature;
 import fish.focus.uvms.rest.security.UnionVMSFeature;
@@ -10,6 +11,8 @@ import javax.ejb.Stateless;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 @Path("asset/rest/internal")
@@ -34,7 +37,19 @@ public class AssetMock {
     @Path("/createPollForAsset/{id}")
     public Response createPoll(@PathParam("id") String assetId, @QueryParam("username") String username, SimpleCreatePoll createPoll) {
         System.setProperty("AssetPollEndpointReached", "True");
-        return Response.ok().entity(Boolean.TRUE).build();
+
+        String assetPollExceptionMessage = System.getProperty("AssetPollExceptionMessage");
+        if (assetPollExceptionMessage != null && !assetPollExceptionMessage.isEmpty()) {
+            return Response.status(500).entity(assetPollExceptionMessage).build();
+        }
+
+        CreatePollResultDto result = new CreatePollResultDto();
+        result.setUnsentPoll(false);
+        result.setUnsentPolls(Collections.emptyList());
+        List<String> sentPolls = List.of(UUID.randomUUID().toString());
+        result.setSentPolls(sentPolls);
+
+        return Response.ok().entity(result).build();
     }
 
     @POST


### PR DESCRIPTION
No longer creates incidents for inactive/parked assets.

AssetMock didn't send back a proper response, but the problem wasn't visible in the tests (except for stacktraces) due to how the error handling in AssetCommunicationBean is set up. AssetClient already has a method for creating a poll, but exception handling and the username are handled differently. Using the AssetClient method would be better as mocking becomes easier and cleaner, but would have to be changed outside of this bug fix.

Refs: FART-534